### PR TITLE
update policy creator token testing docker-compose to reflect how the…

### DIFF
--- a/src/policy_token_gateway/docker-compose.yml
+++ b/src/policy_token_gateway/docker-compose.yml
@@ -29,4 +29,6 @@ services:
       - MYSQL_DATABASE=db
       - PUID=1000
       - PGID=1000
-      - SET_DEFAULT_BROKER=true
+      - BROKER_0=mock,foo,bar
+      - BROKER_1=mock,bar,foo
+      - BROKER_2=mock,baz,foobar


### PR DESCRIPTION
… bccdb works

### Pull Request Checklist ###
- [N/A] Have you used any third party libraries or software?
  - [N/A] Have you checked the [license is acceptable?](https://github.com/sardap/Capstone-2019-Data-Sharing/wiki/%2384_spike_acceptable_licenses)
  - [N/A] Have you updated the [third party library doc?](https://docs.google.com/spreadsheets/d/1JBfES5GyR0PX2k0xXWG1XyFLgJ7_VYJK9HWqUOIve1s/edit#gid=0)
- [X] Is there a Readme for the component if applicable ([Example](https://github.com/sardap/Capstone-2019-Data-Sharing/blob/Development/src/BCF/Fetcher/README.md))
  - [X] Does the Readme include testing information
- [] example

### Related issues

The BCCDB was changed to use environment variables to directly add test brokers into the db.  Previously it was a variable that acted as a flag whether to add in some hard coded values.  This change broke the testing in the policy token creator.  

This updates the testing to handle this change.

@sardap Paul, you broke it you review the fix 
